### PR TITLE
Proper version comparison

### DIFF
--- a/GDO/Install/Method/SystemTest.php
+++ b/GDO/Install/Method/SystemTest.php
@@ -18,10 +18,10 @@ final class SystemTest extends Method
 				FileUtil::createDir(GDO_PATH . 'protected'),
 				FileUtil::createDir(GDO_PATH . 'files'),
 				FileUtil::createDir(GDO_PATH . 'temp'),
-			    FileUtil::createDir(GDO_PATH . 'assets'),
+				FileUtil::createDir(GDO_PATH . 'assets'),
 				$this->testBower(),
 				function_exists('mb_strlen'),
-			    ini_get('date.timezone'),
+				ini_get('date.timezone'),
 			),
 			'optional' => array(
 				function_exists('imagecreate'),
@@ -35,7 +35,7 @@ final class SystemTest extends Method
 	{
 		return version_compare(PHP_VERSION, '5.6.0') >= 0;
 	}
-
+	
 	private function testBower()
 	{
 		return null;

--- a/GDO/Install/Method/SystemTest.php
+++ b/GDO/Install/Method/SystemTest.php
@@ -33,8 +33,7 @@ final class SystemTest extends Method
 	
 	private function testPHPVersion()
 	{
-		$version = floatval(PHP_MAJOR_VERSION. '.' . PHP_MINOR_VERSION);
-		return $version >= 5.6;
+		return version_compare(PHP_VERSION, '5.6.0') >= 0;
 	}
 
 	private function testBower()

--- a/GDO/Install/lang/install_en.php
+++ b/GDO/Install/lang/install_en.php
@@ -46,7 +46,7 @@ return array(
 'install_config_boxinfo_success' => 'Your system looks solid. You can continue with %s',
 'save_config' => 'Save',
 'test_config' => 'Test',
-    
+
 # Modules
 'install_title_4' => 'GDO Modules',
 'install_modules_info_text' => 'Here you can choose the modules to install. Dependencies are not 100% resolved yet.',
@@ -67,7 +67,7 @@ You can paste this into your crontab file:
 
 You can then continue with %s.',
 
-# Admins 
+# Admins
 'install_title_6' => 'Create Admins',
 'ft_install_installadmins' => 'Create Admins',
 'msg_admin_created' => 'An admin named %s has been created or their password has been reset.',
@@ -93,13 +93,13 @@ cd www/gdo6<br/>
 Note: Currently bower and yarn are both in use. Bower will be dropped.<br/>
 </code>
 ',
-	
+
 'install_title_8' => 'Import Backup',
 'ft_install_importbackup' => 'Import a backup',
-	
+
 'install_title_9' => 'Install Security',
 'ft_install_security' => 'Finish installation by removing access to install wizard and the protected folder',
-	
+
 # gdo6 binary
 'msg_config_written' => 'A default config file has been written to protected/%s',
 'msg_available_config' => 'Available config vars for module %s: %s.',

--- a/GDO/Install/lang/install_en.php
+++ b/GDO/Install/lang/install_en.php
@@ -4,11 +4,11 @@ return array(
 'install_title_1' => 'Welcome',
 'install_text_1' => 'Welcome to GDO6, Please continue here: %s',
 'install_text_2' => 'If you plan to use a Database, please execute the following mysql commands.',
-    
+
 # System Test
 'install_title_2' => 'System–Test',
 'install_title_2_tests' => 'Mandatory Requirements',
-'install_test_0' => 'Is PHP Version '.PHP_VERSION.'supported?',
+'install_test_0' => 'Is PHP Version '.PHP_VERSION.' supported?',
 'install_test_1' => 'Is the protected folder writable?',
 'install_test_2' => 'Is the files folder writable?',
 'install_test_3' => 'Is the temp folder writable?',


### PR DESCRIPTION
* Unify indents & line breaks
* Use version_compare instead of hackery
  Use a proper `version_compare` instead of float val hackery. This is
  supported since PHP 4, should not be a problem.
* Add missing space to version check output
