### PR TITLE
Fix `CSV::withHeader()`

### DIFF
--- a/GDO/Util/CSV.php
+++ b/GDO/Util/CSV.php
@@ -33,7 +33,7 @@ final class CSV
     
     public function withHeader($withHeader=true)
     {
-        $this->$withHeader = $withHeader;
+        $this->withHeader = $withHeader;
         return $this;
     }
     


### PR DESCRIPTION
The `CSV::withHeader()` method did not work due to a stray `$`. It would have tried to set the given value to a `$this->true` property.